### PR TITLE
Added a proper install instead of a linkage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This is not an offically supported Firebase repo. This is community-based. So PR
 
 ## Installation - OSX
 1. Clone the repo
-1. run ./link.sh
-1. Profit
+2. run ./install.sh
+3. The cloned folder is safe to remove
 
 ## Installation - Windows
 1. Clone the repo
-1. Move the unzipped files into `C:\Program Files\Sublime Text 3\Packages`
-1. Profit
+2. Move the unzipped files into `C:\Program Files\Sublime Text 3\Packages`
+3. Profit
 
 Copyright 2015 David East
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,23 @@ Syntax highlighting for [the Bolt compiler](https://firebase.com/docs/security/b
 
 This is not an offically supported Firebase repo. This is community-based. So PRs are totally accepted. This is a rough fork of [Brian Ford's JavaScript Sublime Pacakge](https://github.com/btford/sublime-text-javascript).
 
+## Installation - Sublime Package Control
+1. Open the package control menu in Sublime
+2. Choose 'Package Control: Add Repository'
+3. Add this repository
+4. Open the menu again and install the package 'bolt-sublime'
+5. Enjoy!
+
 ## Installation - OSX
 1. Clone the repo
 2. run ./install.sh
 3. The cloned folder is safe to remove
+4. Enjoy!
 
 ## Installation - Windows
 1. Clone the repo
 2. Move the unzipped files into `C:\Program Files\Sublime Text 3\Packages`
-3. Profit
+3. Enjoy!
 
 Copyright 2015 David East
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,1 @@
+cp -r `pwd` $HOME/Library/Application\ Support/Sublime\ Text\ 3/Packages/bolt-sublime

--- a/link.sh
+++ b/link.sh
@@ -1,1 +1,0 @@
-ln -s `pwd` $HOME/Library/Application\ Support/Sublime\ Text\ 3/Packages/bolt-sublime


### PR DESCRIPTION
Instead of just linking the package this will install it. Thereby making the original clone safe to remove without breaking the package.